### PR TITLE
Fixed Typo - deleted an extra single quote

### DIFF
--- a/Chapter 02/example01.py
+++ b/Chapter 02/example01.py
@@ -18,5 +18,5 @@ for layerNum in range(numLayers):
         feature = layer.GetFeature(featureNum)
         featureName = feature.GetField("NAME")
 
-        print("Feature {} has name {}".format(featureNum, featureName'))
+        print("Feature {} has name {}".format(featureNum, featureName))
 


### PR DESCRIPTION
There was a single quote in the final print statement that caused
a syntax error, so I deleted it.